### PR TITLE
地図上に特定の1便の航跡を表示 #4

### DIFF
--- a/backend/app/controllers/api/v1/tracks_controller.rb
+++ b/backend/app/controllers/api/v1/tracks_controller.rb
@@ -1,7 +1,7 @@
 require "csv"
 
 class Api::V1::TracksController < ApplicationController
-  def by_flight
+  def show
     tracks =Track.where(flight_id: params[:flight_id]).order(:timestamp)
 
     if tracks.any?

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   namespace :api do
     namespace :v1 do
-      get 'flights/:flight_id/tracks', to: 'tracks#by_flight'
+      get 'flights/:flight_id/track', to: 'tracks#show'
       resources :airports, only: [:index]
     end
   end

--- a/backend/spec/requests/api/v1/tracks_spec.rb
+++ b/backend/spec/requests/api/v1/tracks_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe "Api::V1::Tracks", type: :request do
-  describe "GET /api/v1/flights/:flight_id/tracks" do
+  describe "GET /api/v1/flights/:flight_id/track" do
     let(:flight_id) { "TEST00001" }
     let!(:tracks) { create_list(:track, 3, flight_id: flight_id) }
 
     context "when flight_id exists" do
       it "returns 200 and the tracks for the flight" do
-        get "/api/v1/flights/#{flight_id}/tracks", headers: { "ACCEPT" => "application/json" }
+        get "/api/v1/flights/#{flight_id}/track", headers: { "ACCEPT" => "application/json" }
 
         expect(response).to have_http_status(:ok)
 
@@ -25,7 +25,7 @@ RSpec.describe "Api::V1::Tracks", type: :request do
 
     context "when flight_id does not exist" do
       it "returns 404 with error" do
-        get "/api/v1/flights/UNKNOWN99999/tracks", headers: { "ACCEPT" => "application/json" }
+        get "/api/v1/flights/UNKNOWN99999/track", headers: { "ACCEPT" => "application/json" }
 
         expect(response).to have_http_status(:not_found)
 

--- a/frontend/src/utils/api/tracks.ts
+++ b/frontend/src/utils/api/tracks.ts
@@ -1,0 +1,31 @@
+type TrackPoint = {
+  timestamp: string;
+  flight_id: string;
+  lat: number;
+  lon: number;
+  alt: number;
+  aircraft_type: string;
+};
+
+const fetchOneDayTrack = async (flightId: string): Promise<TrackPoint[]> => {
+  try {
+    const response = await fetch(`/api/v1/flights/${flightId}/track`, {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${flightId} track`);
+    }
+
+    const data: TrackPoint[] = await response.json();
+    return data;
+  } catch (error) {
+    console.error(`Error fetching track:`, error);
+    return [];
+  }
+};
+
+export type { TrackPoint }
+export { fetchOneDayTrack }


### PR DESCRIPTION
## 変更内容
- 航跡データ取得APIのエンドポイントを変更
  - 変更前: `/api/v1/flights/:flight_id/tracks`
  - 変更後: `/api/v1/flights/:flight_id/track`
- 緯度・経度の配列を Polyline に渡して航跡を地図上に表示する処理を実装 